### PR TITLE
Add basic rustfmt and run a pass over the code

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,4 @@
+max_width = 78
+commemnt_width = 78
+normalize_comments = false
+wrap_comments = true

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -3,10 +3,10 @@ use super::*;
 use crate::util::fd::Fd;
 use crate::{arch, run};
 
-use std::mem::{size_of, size_of_val};
-use std::os::raw::{c_ulong, c_int};
-use std::os::unix::io::FromRawFd;
 use std::io::Result;
+use std::mem::{size_of, size_of_val};
+use std::os::raw::{c_int, c_ulong};
+use std::os::unix::io::FromRawFd;
 
 impl VirtualCpu {
     pub fn new(vm: &VirtualMachine) -> Result<Self> {
@@ -28,14 +28,18 @@ impl VirtualCpu {
         const KVM_GET_REGS: c_ulong = 2156965505;
 
         let mut regs = arch::Registers::default();
-        unsafe { self.fd.ioctl(KVM_GET_REGS, &mut regs)?; }
+        unsafe {
+            self.fd.ioctl(KVM_GET_REGS, &mut regs)?;
+        }
         Ok(regs)
     }
 
     pub fn set_registers(&mut self, regs: arch::Registers) -> Result<()> {
         const KVM_SET_REGS: c_ulong = 1083223682;
 
-        unsafe { self.fd.ioctl(KVM_SET_REGS, &regs)?; }
+        unsafe {
+            self.fd.ioctl(KVM_SET_REGS, &regs)?;
+        }
         Ok(())
     }
 
@@ -43,21 +47,30 @@ impl VirtualCpu {
         const KVM_GET_SREGS: c_ulong = 2167975555;
 
         let mut regs = arch::SpecialRegisters::default();
-        unsafe { self.fd.ioctl(KVM_GET_SREGS, &mut regs)?; }
+        unsafe {
+            self.fd.ioctl(KVM_GET_SREGS, &mut regs)?;
+        }
         Ok(regs)
     }
 
-    pub fn set_special_registers(&mut self, regs: arch::SpecialRegisters) -> Result<()> {
+    pub fn set_special_registers(
+        &mut self,
+        regs: arch::SpecialRegisters,
+    ) -> Result<()> {
         const KVM_SET_SREGS: c_ulong = 1094233732;
 
-        unsafe { self.fd.ioctl(KVM_SET_SREGS, &regs)?; }
+        unsafe {
+            self.fd.ioctl(KVM_SET_SREGS, &regs)?;
+        }
         Ok(())
     }
 
     pub fn run<'b>(&'b mut self) -> Result<Reason<'b>> {
         const KVM_RUN: c_ulong = 44672;
 
-        unsafe { self.fd.ioctl(KVM_RUN, 0)?; }
+        unsafe {
+            self.fd.ioctl(KVM_RUN, 0)?;
+        }
 
         Ok(match (*self.run).exit_reason {
             run::ReasonCode::Hlt => Reason::Halt,
@@ -77,16 +90,16 @@ impl VirtualCpu {
                     run::IoDirection::In => {
                         let data = &mut self.run[start..][..size * count];
                         Reason::Io(ReasonIo::In { port, data })
-                    },
+                    }
 
                     run::IoDirection::Out => {
                         let data = &self.run[start..][..size * count];
                         Reason::Io(ReasonIo::Out { port, data })
-                    },
+                    }
 
                     d => panic!("Unsupported direction: {:?}", d),
                 }
-            },
+            }
 
             run::ReasonCode::Mmio => {
                 let mmio = unsafe { &(*self.run).reason.mmio };
@@ -98,7 +111,7 @@ impl VirtualCpu {
                     data: &mmio.data[..mmio.len as usize],
                     read: mmio.is_write == 0,
                 }
-            },
+            }
 
             r => panic!("Unsupported exit reason: {:?}", r),
         })

--- a/src/kvm.rs
+++ b/src/kvm.rs
@@ -15,7 +15,7 @@ impl Kvm {
             12 => Ok(Self(fd)),
             v => Err(Error::new(
                 ErrorKind::InvalidData,
-                format!("invalid kvm version: {}", v)
+                format!("invalid kvm version: {}", v),
             ))?,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 pub mod arch;
-pub mod util;
 pub mod sev;
+pub mod util;
 
-mod run;
 mod cpu;
 mod kvm;
+mod run;
 mod vm;
 
 use std::collections::HashMap;
@@ -46,5 +46,9 @@ pub enum ReasonIo<'a> {
 pub enum Reason<'a> {
     Halt,
     Io(ReasonIo<'a>),
-    Mmio { addr: u64, data: &'a [u8], read: bool },
+    Mmio {
+        addr: u64,
+        data: &'a [u8],
+        read: bool,
+    },
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,5 +1,5 @@
-use bitflags::bitflags;
 use crate::arch;
+use bitflags::bitflags;
 
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/util/fd.rs
+++ b/src/util/fd.rs
@@ -1,8 +1,8 @@
+use std::fs::File;
+use std::io::*;
 use std::os::raw::{c_uint, c_ulong};
 use std::os::unix::io::*;
 use std::ptr::null;
-use std::fs::File;
-use std::io::*;
 
 pub struct Fd(RawFd);
 
@@ -15,9 +15,15 @@ impl Fd {
         Ok(Fd::new(File::open(file)?))
     }
 
-    pub unsafe fn ioctl<T>(&self, req: impl Into<c_ulong>, data: T) -> Result<c_uint> {
+    pub unsafe fn ioctl<T>(
+        &self,
+        req: impl Into<c_ulong>,
+        data: T,
+    ) -> Result<c_uint> {
         let r = libc::ioctl(self.as_raw_fd(), req.into(), data, null::<u8>());
-        if r < 0 { Err(Error::last_os_error())? }
+        if r < 0 {
+            Err(Error::last_os_error())?
+        }
         Ok(r as c_uint)
     }
 }

--- a/src/util/ioctl.rs
+++ b/src/util/ioctl.rs
@@ -51,7 +51,6 @@ pub const KVM_SET_DEVICE_ATTR: c_ulong = 1075359457;
 pub const KVM_GET_DEVICE_ATTR: c_ulong = 1075359458;
 pub const KVM_HAS_DEVICE_ATTR: c_ulong = 1075359459;
 
-
 pub const KVM_TRANSLATE: c_ulong = 3222843013;
 pub const KVM_INTERRUPT: c_ulong = 1074048646;
 pub const KVM_GET_MSRS: c_ulong = 3221794440;

--- a/src/util/map.rs
+++ b/src/util/map.rs
@@ -1,11 +1,11 @@
-use std::slice::{SliceIndex, from_raw_parts, from_raw_parts_mut};
-use std::ops::{Deref, DerefMut, Index, IndexMut};
-use std::os::unix::io::{AsRawFd, RawFd};
 use std::borrow::{Borrow, BorrowMut};
-use std::os::raw::{c_int, c_void};
-use std::marker::PhantomData;
 use std::io::{Error, Result};
+use std::marker::PhantomData;
 use std::mem::size_of;
+use std::ops::{Deref, DerefMut, Index, IndexMut};
+use std::os::raw::{c_int, c_void};
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::slice::{from_raw_parts, from_raw_parts_mut, SliceIndex};
 
 use bitflags::bitflags;
 
@@ -181,7 +181,9 @@ impl<T: 'static + Copy> Builder<T> {
             )
         };
 
-        if ptr.is_null() { Err(Error::last_os_error())? }
+        if ptr.is_null() {
+            Err(Error::last_os_error())?
+        }
 
         Ok(Map(ptr as *mut T, length))
     }

--- a/tests/sev_launch.rs
+++ b/tests/sev_launch.rs
@@ -1,7 +1,11 @@
-use ketuvim::{Kvm, VirtualMachine, VirtualCpu, MemoryFlags, Reason, ReasonIo, arch, util::map};
-use std::convert::TryFrom;
 use codicon::Decoder;
+use ketuvim::{
+    arch, util::map, Kvm, MemoryFlags, Reason, ReasonIo, VirtualCpu,
+    VirtualMachine,
+};
+use std::convert::TryFrom;
 
+#[rustfmt::skip]
 const CODE: &[u8] = &[
     0xba, 0xf8, 0x03, // mov $0x3f8, %dx
     0x00, 0xd8,       // add %bl, %al
@@ -11,23 +15,25 @@ const CODE: &[u8] = &[
 
 fn fetch_chain(fw: &sev::firmware::Firmware) -> sev::certs::Chain {
     const CEK_SVC: &str = "https://kdsintf.amd.com/cek/id";
-    const NAPLES: &str = "https://developer.amd.com/wp-content/resources/ask_ark_naples.cert";
+    const NAPLES: &str =
+        "https://developer.amd.com/wp-content/resources/ask_ark_naples.cert";
 
-    let mut chain = fw.pdh_cert_export()
+    let mut chain = fw
+        .pdh_cert_export()
         .expect("unable to export SEV certificates");
 
     let id = fw.get_identifer().expect("error fetching identifier");
     let url = format!("{}/{}", CEK_SVC, id);
 
-    let mut rsp = reqwest::get(&url)
-        .expect(&format!("unable to contact server"));
+    let mut rsp =
+        reqwest::get(&url).expect(&format!("unable to contact server"));
     assert!(rsp.status().is_success());
 
     chain.cek = sev::certs::sev::Certificate::decode(&mut rsp, ())
         .expect("Invalid CEK!");
 
-    let mut rsp = reqwest::get(NAPLES)
-        .expect(&format!("unable to contact server"));
+    let mut rsp =
+        reqwest::get(NAPLES).expect(&format!("unable to contact server"));
     assert!(rsp.status().is_success());
 
     sev::certs::Chain {
@@ -56,9 +62,11 @@ fn test() {
         .protection(map::Protection::READ | map::Protection::WRITE)
         .flags(map::Flags::ANONYMOUS)
         .extra(0x1000)
-        .done().unwrap();
+        .done()
+        .unwrap();
     let addr = &*code as *const () as u64;
-    vm.add_region(0, MemoryFlags::default(), 0x1000, code).unwrap();
+    vm.add_region(0, MemoryFlags::default(), 0x1000, code)
+        .unwrap();
 
     // Server takes a measurement and sends it to the client.
     let launch = ketuvim::sev::Launch::new(vm).unwrap();
@@ -69,7 +77,9 @@ fn test() {
     // Client verifies measurement and delivers secret to server.
     let session = session.measure().unwrap();
     let session = session.verify(build, measurement).unwrap();
-    let secret = session.secret(sev::launch::HeaderFlags::default(), CODE).unwrap();
+    let secret = session
+        .secret(sev::launch::HeaderFlags::default(), CODE)
+        .unwrap();
 
     // Server injects the secret into the VM.
     let len = secret.ciphertext.len() as u32;
@@ -90,7 +100,8 @@ fn test() {
         rbx: 2,
         rflags: 0x2,
         ..Default::default()
-    }).unwrap();
+    })
+    .unwrap();
 
     let mut output = None;
 

--- a/tests/triplett.rs
+++ b/tests/triplett.rs
@@ -1,5 +1,6 @@
 use ketuvim::*;
 
+#[rustfmt::skip]
 const CODE: &[u8] = &[
     0xba, 0xf8, 0x03, // mov $0x3f8, %dx
     0x00, 0xd8,       // add %bl, %al
@@ -15,16 +16,20 @@ fn test() {
 
     // Create the code mapping.
     let mut code = util::map::Map::<()>::build(util::map::Access::Shared)
-        .protection(util::map::Protection::READ | util::map::Protection::WRITE)
+        .protection(
+            util::map::Protection::READ | util::map::Protection::WRITE,
+        )
         .flags(util::map::Flags::ANONYMOUS)
         .extra(0x1000)
-        .done().unwrap();
+        .done()
+        .unwrap();
 
     // Copy in the code.
     code[..CODE.len()].copy_from_slice(CODE);
 
     // Add the mapping to the VM.
-    vm.add_region(0, MemoryFlags::default(), 0x1000, code).unwrap();
+    vm.add_region(0, MemoryFlags::default(), 0x1000, code)
+        .unwrap();
 
     // Setup special registers.
     let mut sregs = cpu.special_registers().unwrap();
@@ -39,7 +44,8 @@ fn test() {
         rbx: 2,
         rflags: 0x2,
         ..Default::default()
-    }).unwrap();
+    })
+    .unwrap();
 
     let mut output = None;
 


### PR DESCRIPTION
Mark the ASM byte blocks as skipped to preserve the layout there.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>