### PR TITLE
Run `cargo fmt` to bring formatting up to Enarx standards

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -17,10 +17,10 @@ use super::*;
 use crate::util::fd::Fd;
 use crate::{arch, run};
 
-use std::mem::{size_of, size_of_val};
-use std::os::raw::{c_ulong, c_int};
-use std::os::unix::io::FromRawFd;
 use std::io::Result;
+use std::mem::{size_of, size_of_val};
+use std::os::raw::{c_int, c_ulong};
+use std::os::unix::io::FromRawFd;
 
 impl VirtualCpu {
     pub fn new(vm: &VirtualMachine) -> Result<Self> {
@@ -42,14 +42,18 @@ impl VirtualCpu {
         const KVM_GET_REGS: c_ulong = 2156965505;
 
         let mut regs = arch::Registers::default();
-        unsafe { self.fd.ioctl(KVM_GET_REGS, &mut regs)?; }
+        unsafe {
+            self.fd.ioctl(KVM_GET_REGS, &mut regs)?;
+        }
         Ok(regs)
     }
 
     pub fn set_registers(&mut self, regs: arch::Registers) -> Result<()> {
         const KVM_SET_REGS: c_ulong = 1083223682;
 
-        unsafe { self.fd.ioctl(KVM_SET_REGS, &regs)?; }
+        unsafe {
+            self.fd.ioctl(KVM_SET_REGS, &regs)?;
+        }
         Ok(())
     }
 
@@ -57,21 +61,27 @@ impl VirtualCpu {
         const KVM_GET_SREGS: c_ulong = 2167975555;
 
         let mut regs = arch::SpecialRegisters::default();
-        unsafe { self.fd.ioctl(KVM_GET_SREGS, &mut regs)?; }
+        unsafe {
+            self.fd.ioctl(KVM_GET_SREGS, &mut regs)?;
+        }
         Ok(regs)
     }
 
     pub fn set_special_registers(&mut self, regs: arch::SpecialRegisters) -> Result<()> {
         const KVM_SET_SREGS: c_ulong = 1094233732;
 
-        unsafe { self.fd.ioctl(KVM_SET_SREGS, &regs)?; }
+        unsafe {
+            self.fd.ioctl(KVM_SET_SREGS, &regs)?;
+        }
         Ok(())
     }
 
     pub fn run<'b>(&'b mut self) -> Result<Reason<'b>> {
         const KVM_RUN: c_ulong = 44672;
 
-        unsafe { self.fd.ioctl(KVM_RUN, 0)?; }
+        unsafe {
+            self.fd.ioctl(KVM_RUN, 0)?;
+        }
 
         Ok(match (*self.run).exit_reason {
             run::ReasonCode::Hlt => Reason::Halt,
@@ -91,16 +101,16 @@ impl VirtualCpu {
                     run::IoDirection::In => {
                         let data = &mut self.run[start..][..size * count];
                         Reason::Io(ReasonIo::In { port, data })
-                    },
+                    }
 
                     run::IoDirection::Out => {
                         let data = &self.run[start..][..size * count];
                         Reason::Io(ReasonIo::Out { port, data })
-                    },
+                    }
 
                     d => panic!("Unsupported direction: {:?}", d),
                 }
-            },
+            }
 
             run::ReasonCode::Mmio => {
                 let mmio = unsafe { &(*self.run).reason.mmio };
@@ -112,7 +122,7 @@ impl VirtualCpu {
                     data: &mmio.data[..mmio.len as usize],
                     read: mmio.is_write == 0,
                 }
-            },
+            }
 
             r => panic!("Unsupported exit reason: {:?}", r),
         })

--- a/src/kvm.rs
+++ b/src/kvm.rs
@@ -29,7 +29,7 @@ impl Kvm {
             12 => Ok(Self(fd)),
             v => Err(Error::new(
                 ErrorKind::InvalidData,
-                format!("invalid kvm version: {}", v)
+                format!("invalid kvm version: {}", v),
             ))?,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 pub mod arch;
-pub mod util;
 pub mod sev;
+pub mod util;
 
-mod run;
 mod cpu;
 mod kvm;
+mod run;
 mod vm;
 
 use std::collections::HashMap;
@@ -60,5 +60,9 @@ pub enum ReasonIo<'a> {
 pub enum Reason<'a> {
     Halt,
     Io(ReasonIo<'a>),
-    Mmio { addr: u64, data: &'a [u8], read: bool },
+    Mmio {
+        addr: u64,
+        data: &'a [u8],
+        read: bool,
+    },
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bitflags::bitflags;
 use crate::arch;
+use bitflags::bitflags;
 
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/sev.rs
+++ b/src/sev.rs
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::os::unix::io::AsRawFd;
-use std::mem::uninitialized;
 use std::mem::size_of_val;
+use std::mem::uninitialized;
 use std::os::raw::c_ulong;
+use std::os::unix::io::AsRawFd;
 
-use ::sev::{launch, firmware::{Indeterminate, Error}};
 use super::*;
+use ::sev::{
+    firmware::{Error, Indeterminate},
+    launch,
+};
 
 #[repr(u32)]
 #[allow(dead_code)]
@@ -93,7 +96,11 @@ impl<T> Launch<T> {
 impl Launch<Initialized> {
     pub fn new(vm: VirtualMachine) -> Result<Self> {
         let fw = fd::Fd::open("/dev/sev")?;
-        let l = Launch { state: Initialized, fw, vm };
+        let l = Launch {
+            state: Initialized,
+            fw,
+            vm,
+        };
         l.cmd(Code::Init, ())?;
         Ok(l)
     }
@@ -119,7 +126,11 @@ impl Launch<Initialized> {
         };
 
         let state = Started(Handle(self.cmd(Code::LaunchStart, data)?.handle));
-        Ok(Launch { state, fw: self.fw, vm: self.vm })
+        Ok(Launch {
+            state,
+            fw: self.fw,
+            vm: self.vm,
+        })
     }
 }
 
@@ -158,7 +169,7 @@ impl Launch<Started> {
         Ok(Launch {
             state: Measured(self.state.0, measurement),
             fw: self.fw,
-            vm: self.vm
+            vm: self.vm,
         })
     }
 }

--- a/src/util/fd.rs
+++ b/src/util/fd.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fs::File;
+use std::io::*;
 use std::os::raw::{c_uint, c_ulong};
 use std::os::unix::io::*;
 use std::ptr::null;
-use std::fs::File;
-use std::io::*;
 
 pub struct Fd(RawFd);
 
@@ -31,7 +31,9 @@ impl Fd {
 
     pub unsafe fn ioctl<T>(&self, req: impl Into<c_ulong>, data: T) -> Result<c_uint> {
         let r = libc::ioctl(self.as_raw_fd(), req.into(), data, null::<u8>());
-        if r < 0 { Err(Error::last_os_error())? }
+        if r < 0 {
+            Err(Error::last_os_error())?
+        }
         Ok(r as c_uint)
     }
 }

--- a/src/util/ioctl.rs
+++ b/src/util/ioctl.rs
@@ -65,7 +65,6 @@ pub const KVM_SET_DEVICE_ATTR: c_ulong = 1075359457;
 pub const KVM_GET_DEVICE_ATTR: c_ulong = 1075359458;
 pub const KVM_HAS_DEVICE_ATTR: c_ulong = 1075359459;
 
-
 pub const KVM_TRANSLATE: c_ulong = 3222843013;
 pub const KVM_INTERRUPT: c_ulong = 1074048646;
 pub const KVM_GET_MSRS: c_ulong = 3221794440;

--- a/src/util/map.rs
+++ b/src/util/map.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::slice::{SliceIndex, from_raw_parts, from_raw_parts_mut};
-use std::ops::{Deref, DerefMut, Index, IndexMut};
-use std::os::unix::io::{AsRawFd, RawFd};
 use std::borrow::{Borrow, BorrowMut};
-use std::os::raw::{c_int, c_void};
-use std::marker::PhantomData;
 use std::io::{Error, Result};
+use std::marker::PhantomData;
 use std::mem::size_of;
+use std::ops::{Deref, DerefMut, Index, IndexMut};
+use std::os::raw::{c_int, c_void};
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::slice::{from_raw_parts, from_raw_parts_mut, SliceIndex};
 
 use bitflags::bitflags;
 
@@ -195,7 +195,9 @@ impl<T: 'static + Copy> Builder<T> {
             )
         };
 
-        if ptr.is_null() { Err(Error::last_os_error())? }
+        if ptr.is_null() {
+            Err(Error::last_os_error())?
+        }
 
         Ok(Map(ptr as *mut T, length))
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -15,9 +15,9 @@
 use super::*;
 use crate::util::map::Map;
 
+use std::io::{ErrorKind, Result};
 use std::os::raw::{c_int, c_uint, c_ulong};
 use std::os::unix::io::FromRawFd;
-use std::io::{ErrorKind, Result};
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -48,7 +48,7 @@ impl VirtualMachine {
             multi_addr_space: limit,
             vcpu_mmap_size: size,
             mem: HashMap::new(),
-            fd
+            fd,
         })
     }
 
@@ -57,7 +57,7 @@ impl VirtualMachine {
         space: u16,
         flags: MemoryFlags,
         addr: u64,
-        mut map: Map<T>
+        mut map: Map<T>,
     ) -> Result<u16> {
         const KVM_SET_USER_MEMORY_REGION: c_ulong = 1075883590;
 
@@ -76,7 +76,9 @@ impl VirtualMachine {
             userspace_addr: &mut *map as *mut T as u64,
         };
 
-        unsafe { self.fd.ioctl(KVM_SET_USER_MEMORY_REGION, &mut region)?; }
+        unsafe {
+            self.fd.ioctl(KVM_SET_USER_MEMORY_REGION, &mut region)?;
+        }
 
         maps.push(unsafe { map.cast() });
         Ok(slot as u16)

--- a/tests/triplett.rs
+++ b/tests/triplett.rs
@@ -16,9 +16,9 @@ use ketuvim::*;
 
 const CODE: &[u8] = &[
     0xba, 0xf8, 0x03, // mov $0x3f8, %dx
-    0x00, 0xd8,       // add %bl, %al
-    0xee,             // out %al, (%dx)
-    0xf4,             // hlt
+    0x00, 0xd8, // add %bl, %al
+    0xee, // out %al, (%dx)
+    0xf4, // hlt
 ];
 
 #[test]
@@ -32,13 +32,15 @@ fn test() {
         .protection(util::map::Protection::READ | util::map::Protection::WRITE)
         .flags(util::map::Flags::ANONYMOUS)
         .extra(0x1000)
-        .done().unwrap();
+        .done()
+        .unwrap();
 
     // Copy in the code.
     code[..CODE.len()].copy_from_slice(CODE);
 
     // Add the mapping to the VM.
-    vm.add_region(0, MemoryFlags::default(), 0x1000, code).unwrap();
+    vm.add_region(0, MemoryFlags::default(), 0x1000, code)
+        .unwrap();
 
     // Setup special registers.
     let mut sregs = cpu.special_registers().unwrap();
@@ -53,7 +55,8 @@ fn test() {
         rbx: 2,
         rflags: 0x2,
         ..Default::default()
-    }).unwrap();
+    })
+    .unwrap();
 
     let mut output = None;
 


### PR DESCRIPTION
The Enarx project uses standard cargo fmt formatting as our standard, and sevctl does not meet those standards. This PR fixes that.