### PR TITLE
Add Travis config to run rustfmt test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+# Copyright 2019 Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true
+install:
+  - rustup component add rustfmt
+script:
+  - cargo fmt -- --check


### PR DESCRIPTION
To enforce proper formatting standards on Enarx projects, we'd like to run cargo fmt on all incoming pull requests to Enarx projects. This enables the appropriate test using Travis CI.

Resolves #6.