### PR TITLE
sev: re-export the sev crate

### DIFF
--- a/src/sev.rs
+++ b/src/sev.rs
@@ -23,6 +23,9 @@ use ::sev::{
     launch,
 };
 
+/// Re-export of the `sev` crate to mitigate version conflicts in consumers
+pub use ::sev;
+
 #[repr(u32)]
 #[allow(dead_code)]
 #[derive(Copy, Clone)]


### PR DESCRIPTION
This re-export can be used by consumers to ensure their using the same
sev version as this library.

/cc(review appreciated) @zeenix
/cc(FYI) @npmccallum